### PR TITLE
Bug fix when parsing data received into a `ChannelMessage`, as described in #17

### DIFF
--- a/clients/client-dart/lib/src/json_decoder.dart
+++ b/clients/client-dart/lib/src/json_decoder.dart
@@ -1,15 +1,18 @@
 import 'dart:convert';
-import 'package:validators/validators.dart';
+import 'package:logging/logging.dart';
 import 'channel_message.dart';
 import 'message_decoder.dart';
 import 'utils.dart';
+
 class JsonDecoder extends MessageDecoder<String> {
+
+  final _log = Logger('AsyncClient');
 
   @override
   ChannelMessage decode(String event) {
-
-    var event_as_list = _tokenize(_removeKeys(event));
     
+    var event_as_list = jsonDecode('{"received": $event }')['received'];
+
     var msg = ChannelMessage(Utils.checkString(event_as_list[0]), 
       Utils.checkString(event_as_list[1]),
       Utils.checkString(event_as_list[2]),
@@ -18,28 +21,15 @@ class JsonDecoder extends MessageDecoder<String> {
     var data = Utils.checkString(event_as_list[3]);
 
     if (data != null) {
-      if (isJSON(data)) {
+      try {
         msg.payload = jsonDecode(data);
-      } else {
+      } catch (e) {
+        _log.warning('payload its not decodeable to json');
         msg.payload = data;
       }
     }
 
     return msg;
-  }
-
-  String _removeKeys(String event) {
-    return event.replaceAll(RegExp(r'(^\[)'), '')
-      .replaceAll(RegExp(r'(]$)'), '');
-  }
-
-  List<String> _tokenize(String event) {
-    return event.split(RegExp(r',(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)'))
-      .map((e) => e.trim())
-      .map((e) => e.replaceAll(RegExp(r'["]{2}'), ''))
-      .map((e) => e.replaceAll(RegExp(r'^"'), ''))
-      .map((e) => e.replaceAll(RegExp(r'"$'), ''))
-      .toList();
   }
 
 }

--- a/clients/client-dart/test/json_decoder_test.dart
+++ b/clients/client-dart/test/json_decoder_test.dart
@@ -26,20 +26,67 @@ void main() {
       expect(msg.payload, equals(''));
     });
 
-    test('should parse user event', () {
-      // final json_string = '''
-      // { "message_id": "001", "event": "foo.event", "correlation_id": "bar", "payload": { "hello": "world" } }
-      // ''';
-
+    test('should parse user event with json content', () {
       final trama =
-          '["001", "002", "foo.event", "{\"body\": \"Hello World\"}"]';
+          '["msg-id-0001","correlation-id-002","event.productCreated","{\\"code\\":\\"100\\", \\"title\\":\\"process after 5000ms\\", \\"detail\\":\\"some detail 89bd02d1da483efaa5389cbd4ca65bbd\\", \\"level\\":\\"info\\"}"]';
 
       final msg = JsonDecoder().decode(trama);
+
       expect(msg, isNotNull);
-      expect(msg.messageId, equals('001'));
-      expect(msg.event, equals('foo.event'));
-      expect(msg.correlationId, equals('002'));
+      expect(msg.messageId, equals('msg-id-0001'));
+      expect(msg.correlationId, equals('correlation-id-002'));
+      expect(msg.event, equals('event.productCreated'));
       expect(msg.payload, isMap);
+      expect(msg.payload['code'], equals('100'));
+      expect(msg.payload['title'], equals('process after 5000ms'));
+      expect(msg.payload['detail'], equals('some detail 89bd02d1da483efaa5389cbd4ca65bbd'));
+      expect(msg.payload['level'], equals('info'));
     });
+
+    test('should parse user event with no json content', () {
+
+      final trama =
+          '["msg-id-0003","correlation-id-004","event.productCreated","Hello World"]';
+
+      final msg = JsonDecoder().decode(trama);
+
+      expect(msg, isNotNull);
+      expect(msg.messageId, equals('msg-id-0003'));
+      expect(msg.correlationId, equals('correlation-id-004'));
+      expect(msg.event, equals('event.productCreated'));
+      expect(msg.payload, equals('Hello World'));
+    });
+
+    test('should parse user event with no payload', () {
+
+      final trama =
+          '["msg-id-0003","correlation-id-004","event.productCreated",""]';
+
+      final msg = JsonDecoder().decode(trama);
+
+      expect(msg, isNotNull);
+      expect(msg.messageId, equals('msg-id-0003'));
+      expect(msg.correlationId, equals('correlation-id-004'));
+      expect(msg.event, equals('event.productCreated'));
+      expect(msg.payload, equals(''));
+    });
+
+    test('should parse user event with weird payload', () {
+
+      final trama =
+          '["msg-id-0003","correlation-id-004","event.productCreated",".,.,.,%%#@"]';
+
+      final msg = JsonDecoder().decode(trama);
+
+      expect(msg, isNotNull);
+      expect(msg.messageId, equals('msg-id-0003'));
+      expect(msg.correlationId, equals('correlation-id-004'));
+      expect(msg.event, equals('event.productCreated'));
+      expect(msg.payload, equals('.,.,.,%%#@'));
+    });
+
   });
+
+  
+
 }


### PR DESCRIPTION
## Description

Solution for #17: 

- When converting a received message from the backend into a `ChannelMessage`, there was a bug incorrectly splitting the data received.
- Avoiding processing the data with regexp's, and in turn using `jsonDecode` from `dart:convert` package for a workaround.

## Category

- [ ] Feature
- [x] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [ ] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
