### PR TITLE
Registering eventListeners with event expression

### DIFF
--- a/clients/client-js/README.md
+++ b/clients/client-js/README.md
@@ -51,3 +51,10 @@ client.listenEvent("event.some-name", (message) =>
   someCallback(message.payload)
 );
 ```
+
+You can also use amqp-match style name expressions when susbscribing to events. Examples:
+
+```javascript
+client.listenEvent("event.#", message => someCallback(message.payload));
+client.listenEvent("event.some.*", message => someCallback(message.payload));
+```

--- a/clients/client-js/package-lock.json
+++ b/clients/client-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chanjs-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/clients/client-js/package.json
+++ b/clients/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chanjs-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AsycnDataflow websocket browser client. By Bancolombia",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/client-js/src/async-client.ts
+++ b/clients/client-js/src/async-client.ts
@@ -140,8 +140,14 @@ export class AsyncClient {
 
     private handleMessage(message: ChannelMessage) {
         this.bindings
-            .filter(handler => handler.eventName == message.event)
+            .filter(handler => this.matchHandlerExpr(handler.eventName, message.event))
             .forEach(handler => handler.callBack(message))
+    }
+
+    private matchHandlerExpr(eventExpr: string, actualEventName: string): boolean {
+        if (eventExpr === actualEventName) return true;
+        var regexString = '^' + eventExpr.replace(/\*/g, '([^.]+)').replace(/#/g, '([^.]+\.?)+') + '$';
+        return actualEventName.search(regexString) !== -1;
     }
 
     private ackMessage(message: ChannelMessage){


### PR DESCRIPTION
## Description

Implements event listener registration with amqp-match style expressions.
Closes #21 

## Category

- [x] Feature
- [ ] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the package.json was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
