### PR TITLE
Separate exchange creds and routing processes

### DIFF
--- a/clients/backend-client-elixir/lib/adf_sender_connector/router.ex
+++ b/clients/backend-client-elixir/lib/adf_sender_connector/router.ex
@@ -33,6 +33,7 @@ defmodule AdfSenderConnector.Router do
     build_protocol_msg(Keyword.fetch!(state, :name), message, event_name)
     |> build_route_request
     |> do_route_msg(state)
+    |> decode_response
     {:noreply, state}
   end
 
@@ -41,6 +42,8 @@ defmodule AdfSenderConnector.Router do
     %{protocol_message | channel_ref: Keyword.fetch!(state, :name)}
     |> build_route_request
     |> do_route_msg(state)
+    |> decode_response
+    
     {:noreply, state}
   end
 

--- a/clients/backend-client-elixir/mix.exs
+++ b/clients/backend-client-elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule AdfSenderConnector.MixProject do
   def project do
     [
       app: :adf_sender_connector,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/clients/backend-client-elixir/test/adf_sender_connector/channel_test.exs
+++ b/clients/backend-client-elixir/test/adf_sender_connector/channel_test.exs
@@ -3,7 +3,7 @@ Code.compiler_options(ignore_module_conflict: true)
 defmodule AdfSenderConnector.ChannelTest do
   use ExUnit.Case
   import Mock
-  alias AdfSenderConnector.Channel
+  alias AdfSenderConnector.Credentials
 
   @moduletag :capture_log
 
@@ -32,7 +32,7 @@ defmodule AdfSenderConnector.ChannelTest do
       {HTTPoison, [], [post: fn _url, _params, _headers, _opts -> {:ok, create_response} end]}
     ]) do
 
-      {:ok, pid} = Channel.start_link({:sender_url, "http://localhost:8888"}, options)
+      {:ok, pid} = Credentials.start_link({:sender_url, "http://localhost:8888"}, options)
       assert is_pid(pid)
       Process.exit(pid, :normal)
 
@@ -53,10 +53,10 @@ defmodule AdfSenderConnector.ChannelTest do
       {HTTPoison, [], [post: fn _url, _params, _headers, _opts -> {:ok, create_response} end]}
     ]) do
 
-      {:ok, pid} = Channel.start_link({:sender_url, "http://localhost:8888"}, options)
+      {:ok, pid} = Credentials.start_link({:sender_url, "http://localhost:8888"}, options)
       assert is_pid(pid)
 
-      {:ok, _response} = Channel.exchange_credentials(pid)
+      {:ok, _response} = Credentials.exchange_credentials(pid)
 
       Process.exit(pid, :normal)
     end


### PR DESCRIPTION
## Description

Separation of exchanging credentials and routing processes. In order to allow to search the later by channel reference.

## Category

- [x] Feature
- [ ] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
