### PR TITLE
configurations for erlang cluster runtime config

### DIFF
--- a/channel-sender/.dockerignore
+++ b/channel-sender/.dockerignore
@@ -1,3 +1,4 @@
 _build
+.elixir_ls
 deps
-erl_crash.dump
+*.dump

--- a/channel-sender/Dockerfile
+++ b/channel-sender/Dockerfile
@@ -3,7 +3,7 @@
 #===============
 FROM elixir:1.12-alpine as build
 
-ARG BUILD_ENV=dev
+ARG BUILD_ENV=prod
 ARG BUILD_VER=0.1.2
 
 WORKDIR /build

--- a/channel-sender/README.md
+++ b/channel-sender/README.md
@@ -48,25 +48,22 @@ Run make `https://editor.swagger.io/` add the `swagger.yaml` file and you get a 
 
 In the shell:
 
-```elixir
-iex -S mix
-or
- MIX_ENV=<CONFIG-FILE-NAME> iex --erl "-name async-node1@127.0.0.1" -S mix
+```bash
+$ iex -S mix
 ```
 
-### Connect nodes
+or to run several instances locally
 
-Can connect the nodes with a self-discovery strategy as a central register or broadcast, you can also connect the nodes manually with the following task. **this task is useful in development environment.**
+```bash
+$ MIX_ENV=<CONFIG-FILE-NAME> iex --erl "-name async-node1@127.0.0.1" -S mix
 
-```elixir
-Node.connect(:"node-name@ip")
 ```
 
-and verify with:
+### Connect nodes in erlang cluster in k8s
 
-```elixir
-Node.list()
-```
+ADF Sender incorporate `libcluster` dependency in order to facilitate the automatic configuration of erlang clusters in kubernetes.
+
+In folder `deploy_samples\k8s` we have included manifests to deploy ADF sender on kubernetes (and also if istio is present).
 
 ## Clients
 

--- a/channel-sender/config/benchee.exs
+++ b/channel-sender/config/benchee.exs
@@ -10,4 +10,7 @@ config :channel_sender_ex,
   no_start: true,
   socket_idle_timeout: 60000,
   socket_port: 8082,
-  rest_port: 8081
+  rest_port: 8081,
+  topology: [
+    strategy: Cluster.Strategy.Gossip
+  ]

--- a/channel-sender/config/dev.exs
+++ b/channel-sender/config/dev.exs
@@ -9,5 +9,5 @@ config :channel_sender_ex,
   rest_port: 8081,
   max_age: 900,
   topology: [
-      strategy: Cluster.Strategy.Gossip
+    strategy: Cluster.Strategy.Gossip
   ]

--- a/channel-sender/config/dev1.exs
+++ b/channel-sender/config/dev1.exs
@@ -7,4 +7,7 @@ config :channel_sender_ex,
        initial_redelivery_time: 900,
        socket_idle_timeout: 30000,
        rest_port: 8091,
-       max_age: 900
+       max_age: 900,
+       topology: [
+        strategy: Cluster.Strategy.Gossip
+      ]

--- a/channel-sender/config/dev2.exs
+++ b/channel-sender/config/dev2.exs
@@ -7,4 +7,7 @@ config :channel_sender_ex,
        initial_redelivery_time: 900,
        socket_idle_timeout: 30000,
        rest_port: 8071,
-       max_age: 900
+       max_age: 900,
+       topology: [
+        strategy: Cluster.Strategy.Gossip
+      ]

--- a/channel-sender/config/prod.exs
+++ b/channel-sender/config/prod.exs
@@ -1,17 +1,10 @@
 import Config
 
 config :channel_sender_ex,
-  secret_base:
-    {"aV4ZPOf7T7HX6GvbhwyBlDM8B9jfeiwi+9qkBnjXxUZXqAeTrehojWKHkV3U0kGc", "socket auth"},
-  socket_port: 8082,
-  initial_redelivery_time: 900,
-  socket_idle_timeout: 30000,
-  rest_port: 8081,
-  max_age: 900,
-  topology: [
-    strategy: Elixir.Cluster.Strategy.Kubernetes.DNS,
-      config: [
-        service: "adfsender-nodes",
-        application_name: "adfsender"
-      ]
-    ]
+       secret_base:
+         {"aV4ZPOf7T7HX6GvbhwyBlDM8B9jfeiwi+9qkBnjXxUZXqAeTrehojWKHkV3U0kGc", "socket auth"},
+       socket_port: 8092,
+       initial_redelivery_time: 900,
+       socket_idle_timeout: 30000,
+       rest_port: 8091,
+       max_age: 900

--- a/channel-sender/config/runtime.exs
+++ b/channel-sender/config/runtime.exs
@@ -1,0 +1,24 @@
+import Config
+
+if (config_env() == :prod) do
+  config :channel_sender_ex,
+  secret_base:
+  {"aV4ZPOf7T7HX6GvbhwyBlDM8B9jfeiwi+9qkBnjXxUZXqAeTrehojWKHkV3U0kGc", "socket auth"},
+  socket_port: 8082,
+  initial_redelivery_time: 900,
+  socket_idle_timeout: 30000,
+  rest_port: 8081,
+  max_age: 900,
+  topology: [
+    strategy: Cluster.Strategy.Kubernetes,
+      config: [
+        mode: :hostname,
+        kubernetes_ip_lookup_mode: :pods,
+        kubernetes_service_name: "adfsender-headless",
+        kubernetes_node_basename: "channel_sender_ex",
+        kubernetes_selector: "cluster=beam",
+        namespace: "sendernm",
+        polling_interval: 5000
+      ]
+  ]
+end

--- a/channel-sender/config/test.exs
+++ b/channel-sender/config/test.exs
@@ -9,4 +9,7 @@ config :channel_sender_ex,
   max_age: 900,
   socket_idle_timeout: 60000,
   socket_port: 8082,
-  rest_port: 8081
+  rest_port: 8081,
+  topology: [
+    strategy: Cluster.Strategy.Gossip
+  ]

--- a/channel-sender/deploy_samples/k8s/app.yaml
+++ b/channel-sender/deploy_samples/k8s/app.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: adfsender
+  namespace: sendernm
+  labels:
+    app: adfsender
+spec:
+  selector:
+    app: adfsender
+  ports:
+    - name: socket-http
+      targetPort: 8082
+      port: 8082
+    - name: rest-http
+      targetPort: 8081
+      port: 8081        
+---
+## headless service to allow pod to pod comunication for epmd port
+apiVersion: v1
+kind: Service
+metadata:
+  name: adfsender-headless
+  namespace: sendernm 
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: adfsender
+  ports:
+    - name: epmd-tcp
+      port: 4369
+      targetPort: 4369
+      protocol: TCP     
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: adfsender
+  namespace: sendernm
+  labels:
+    app: adfsender
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: adfsender
+      cluster: beam
+  serviceName: "adfsender-headless"
+  template:
+    metadata:
+      annotations:
+        ## annotations required for istio-proxy to detect ports
+        traffic.sidecar.istio.io/includeOutboundPorts: "4369"
+        traffic.sidecar.istio.io/includeInboundPorts: "4369, 8081, 8082"
+      labels:
+        app: adfsender
+        cluster: beam
+    spec:
+      containers:
+        - name: adfsender
+          image: bancolombia/async-dataflow-channel-sender:0.1.2
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name    # requires read-pods-role role 
+            - name: POD_NAME_DNS  # see declared file env.sh in configMap
+              value: adfsender-headless.sendernm.svc.cluster.local                          
+            - name: RELEASE_COOKIE
+              value: "secret"
+          ports:
+            - name: rest-http
+              protocol: TCP
+              containerPort: 8081
+            - name: socket-http
+              protocol: TCP
+              containerPort: 8082
+            - name: epmd-tcp
+              protocol: TCP
+              containerPort: 4369
+          resources:
+            requests:
+              cpu: 250m
+              memory: 150M
+            limits:
+              cpu: 250m
+              memory: 250M
+          volumeMounts:
+          - name: config-volume
+            mountPath: /app/releases/0.1.2/env.sh
+            subPath: env.sh
+          - name: config-volume
+            mountPath: /app/releases/0.1.2/runtime.exs
+            subPath: runtime.exs
+      volumes:
+        - name: config-volume
+          configMap:
+            name: adfsender-config-env

--- a/channel-sender/deploy_samples/k8s/configmap.yaml
+++ b/channel-sender/deploy_samples/k8s/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adfsender-config-env
+  namespace: sendernm
+data:
+  env.sh: |-
+    #!/bin/sh
+    export RELEASE_DISTRIBUTION=name
+    export RELEASE_NODE=channel_sender_ex@${POD_NAME}.${POD_NAME_DNS}
+  runtime.exs: |-
+    import Config
+
+    config :channel_sender_ex,
+    secret_base:
+      {"aV4ZPOf7T7HX6GvbhwyBlDM8B9jfeiwi+9qkBnjXxUZXqAeTrehojWKHkV3U0kGc", "socket auth"},
+    socket_port: 8082,
+    initial_redelivery_time: 900,
+    socket_idle_timeout: 30000,
+    rest_port: 8081,
+    max_age: 900,
+    # libcluster topology for this demostration. 
+    # To see other topologies supported by libcluster 
+    # see library documentation.
+    topology: [
+      strategy: Cluster.Strategy.Kubernetes,
+        config: [
+          mode: :hostname,
+          kubernetes_ip_lookup_mode: :pods,
+          kubernetes_service_name: "adfsender-headless",
+          kubernetes_node_basename: "channel_sender_ex",
+          kubernetes_selector: "cluster=beam",
+          namespace: "sendernm",
+          polling_interval: 5000
+        ]
+    ]
+
+

--- a/channel-sender/deploy_samples/k8s/gateway.yaml
+++ b/channel-sender/deploy_samples/k8s/gateway.yaml
@@ -1,0 +1,87 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: adfsender-gw
+  namespace: sendernm
+spec:
+  selector:
+    istio: ingressgateway 
+  servers:
+    - port:
+        name: secure-port
+        number: 443
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: adfsender-credential
+      hosts:
+        - adfsender.example.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: adfsender-vs-socket
+  namespace: sendernm
+spec:
+  hosts:
+    - adfsender.example.com
+  gateways:
+    - adfsender-gw
+  http:
+    - match:
+        - uri:
+            prefix: /ext/socket
+      rewrite:
+        uri: /ext/socket
+      route:
+        - destination:
+            host: adfsender
+            port:
+              number: 8082
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: adfsender-vs-registration
+  namespace: sendernm
+spec:
+  hosts:
+    - adfsender
+  http:
+    - match:
+        - uri:
+            prefix: /ext/channel
+      rewrite:
+        uri: /ext/channel
+      route:
+        - destination:
+            host: adfsender
+            port:
+              number: 8081
+    - match:
+        - uri:
+            prefix: /health
+      rewrite:
+        uri: /health
+      route:
+        - destination:
+            host: adfsender
+            port:
+              number: 8081              
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: adfsender-vs-epmd
+  namespace: sendernm
+spec:
+  hosts:
+  - adfsender-headless
+  tcp:
+  - match:
+    - port: 4369
+    route:
+    - destination:
+        host: adfsender-headless
+        port:
+          number: 4369   

--- a/channel-sender/deploy_samples/k8s/namespace.yaml
+++ b/channel-sender/deploy_samples/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sendernm
+  labels:
+    istio-injection: enabled

--- a/channel-sender/deploy_samples/k8s/roles.yaml
+++ b/channel-sender/deploy_samples/k8s/roles.yaml
@@ -1,0 +1,34 @@
+## rol required to allow query of existing pods in namespace
+## in order to form the erlang cluster.
+## This is required by libcluster strategy Cluster.Strategy.Kubernetes.
+## To see other strategies supported by libcluster, see library documentation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: read-pods-role
+  namespace: sendernm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: role-binding
+  namespace: sendernm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-pods-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: sendernm

--- a/channel-sender/lib/channel_sender_ex/application.ex
+++ b/channel-sender/lib/channel_sender_ex/application.ex
@@ -7,7 +7,6 @@ defmodule ChannelSenderEx.Application do
   use Application
   @no_start Application.get_env(:channel_sender_ex, :no_start)
   @http_port Application.get_env(:channel_sender_ex, :rest_port, 8080)
-  @topology Application.get_env(:channel_sender_ex, :topology, [ strategy: Cluster.Strategy.Gossip ])
 
   def start(_type, _args) do
     ChannelSenderEx.Utils.ClusterUtils.discover_and_connect_local()
@@ -35,7 +34,7 @@ defmodule ChannelSenderEx.Application do
 
   defp topologies do
     [
-      background_job: @topology
-    ]
+      k8s: Application.get_env(:channel_sender_ex, :topology)
+    ] |> IO.inspect
   end
 end


### PR DESCRIPTION
## Description

Setup configuration for erlang cluster definition via `libcluster` and provide demo configuration for k8s deployment.

## Category

- [x] Feature
- [ ] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [ ] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
