### PR TITLE
fix rest port on mix env prod file

### DIFF
--- a/channel-sender/Dockerfile
+++ b/channel-sender/Dockerfile
@@ -4,7 +4,7 @@
 FROM elixir:1.12-alpine as build
 
 ARG BUILD_ENV=prod
-ARG BUILD_VER=0.1.2
+ARG BUILD_VER=0.1.3
 
 WORKDIR /build
 

--- a/channel-sender/config/prod.exs
+++ b/channel-sender/config/prod.exs
@@ -3,8 +3,8 @@ import Config
 config :channel_sender_ex,
        secret_base:
          {"aV4ZPOf7T7HX6GvbhwyBlDM8B9jfeiwi+9qkBnjXxUZXqAeTrehojWKHkV3U0kGc", "socket auth"},
-       socket_port: 8092,
+       socket_port: 8082,
        initial_redelivery_time: 900,
        socket_idle_timeout: 30000,
-       rest_port: 8091,
+       rest_port: 8081,
        max_age: 900

--- a/channel-sender/deploy_samples/k8s/app.yaml
+++ b/channel-sender/deploy_samples/k8s/app.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
         - name: adfsender
-          image: bancolombia/async-dataflow-channel-sender:0.1.2
+          image: bancolombia/async-dataflow-channel-sender:0.1.3
           env:
             - name: POD_NAME
               valueFrom:
@@ -88,10 +88,10 @@ spec:
               memory: 250M
           volumeMounts:
           - name: config-volume
-            mountPath: /app/releases/0.1.2/env.sh
+            mountPath: /app/releases/0.1.3/env.sh
             subPath: env.sh
           - name: config-volume
-            mountPath: /app/releases/0.1.2/runtime.exs
+            mountPath: /app/releases/0.1.3/runtime.exs
             subPath: runtime.exs
       volumes:
         - name: config-volume

--- a/channel-sender/mix.exs
+++ b/channel-sender/mix.exs
@@ -4,7 +4,7 @@ defmodule ChannelSenderEx.MixProject do
   def project do
     [
       app: :channel_sender_ex,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Description

Fix rest port on `channel-sender/config/prod.exs` to maintain standard ports:  8081 for rest and 8082 for sockets

## Category

- [ ] Feature
- [x] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
