### PR TITLE
feat: changed behaviour calculating the time channel will remain in wait state

### DIFF
--- a/channel-sender/config/config-local.yaml
+++ b/channel-sender/config/config-local.yaml
@@ -16,8 +16,10 @@ channel_sender_ex:
   # before closing the channel
   socket_idle_timeout: 30000
 
-  # Specifies the maximum time (in milliseconds) that the supervisor waits 
-  # for child processes to terminate after sending it an exit signal (:shutdown).
+  # Specifies the maximum time (in milliseconds) that the Elixir supervisor waits 
+  # for child channel processes to terminate after sending it an exit signal 
+  # (:shutdown). This time is used by all gen_statem processes to perform clean up
+  # operations before shutting down.
   channel_shutdown_tolerance: 10000
 
   # Specifies the maximum drift time (in seconds) the channel process
@@ -41,6 +43,22 @@ channel_sender_ex:
   # Allowed max number of messages pending to be sent to a channel
   # received by sender while on waiting state (no socket connection)
   max_pending_queue: 100
+
+  # channel_shutdown_socket_disconnect: Defines the waiting time of the channel process
+  # after a socket disconnection, in case the client re-connects. The disconection can be
+  # clean or unclean. The channel process will wait for the client to re-connect before
+  #
+  # on_clean_close: time in seconds to wait before shutting down the channel process when a 
+  # client explicitlly ends the socket connection (clean close). A value of 0, will
+  # terminate the channel process immediately. This value should never be greater than max_age.
+  #
+  # on_disconnection: time in seconds to wait before shutting down the channel process when the
+  # connectin between the client and server accidentally or unintendedlly is interrupted. 
+  # A value of 0, will terminate the channel process immediately. This value should never 
+  # be greater than max_age.
+  channel_shutdown_socket_disconnect: 
+    on_clean_close: 30
+    on_disconnection: 300
 
   no_start: false
   topology:

--- a/channel-sender/lib/channel_sender_ex/application_config.ex
+++ b/channel-sender/lib/channel_sender_ex/application_config.ex
@@ -102,6 +102,13 @@ defmodule ChannelSenderEx.ApplicationConfig do
       Map.get(fetch(config, :channel_sender_ex), "max_pending_queue", 100)
     )
 
+    channel_wait_times = Map.get(fetch(config, :channel_sender_ex),
+      "channel_shutdown_socket_disconnect", %{"on_clean_close" => 30, "on_disconnection" => 300})
+    Application.put_env(:channel_sender_ex, :channel_shutdown_on_clean_close,
+      Map.get(channel_wait_times, "on_clean_close", 30))
+    Application.put_env(:channel_sender_ex, :channel_shutdown_on_disconnection,
+      Map.get(channel_wait_times, "on_disconnection", 300))
+
     Application.put_env(:channel_sender_ex, :topology, parse_libcluster_topology(config))
 
     if config == %{} do

--- a/channel-sender/lib/channel_sender_ex/core/pubsub/socket_event_bus.ex
+++ b/channel-sender/lib/channel_sender_ex/core/pubsub/socket_event_bus.ex
@@ -6,8 +6,18 @@ defmodule ChannelSenderEx.Core.PubSub.SocketEventBus do
   alias ChannelSenderEx.Core.Channel
   alias ChannelSenderEx.Core.ChannelRegistry
 
+  # Notify the event of a socket connection. Receiving part is the channel process.
   def notify_event({:connected, channel}, socket_pid) do
     connect_channel(channel, socket_pid)
+  end
+
+  # Notify the event with the reason of a socket disconnection. Receiving part is
+  # the channel process. This will be used to determine the time the process
+  # will be waiting for the socket re-connection. Depending on configuration the
+  # waiting time may actually be zero and the process then shuts down inmediately.
+  # See config element: `channel_shutdown_socket_disconnect`
+  def notify_event({:socket_down_reason, channel_ref, reason}, _socket_pid) do
+    socket_disconnect_reason(channel_ref, reason)
   end
 
   def connect_channel(_, _, count \\ 0)
@@ -23,6 +33,21 @@ defmodule ChannelSenderEx.Core.PubSub.SocketEventBus do
       :noproc ->
         Process.sleep(350)
         connect_channel(channel, socket_pid, count + 1)
+    end
+  end
+
+  defp socket_disconnect_reason(channel, reason) do
+    case look_channel(channel) do
+      pid when is_pid(pid) ->
+        Channel.socket_disconnect_reason(pid, reason)
+      :noproc -> :noproc
+    end
+  end
+
+  defp look_channel(channel) do
+    case ChannelRegistry.lookup_channel_addr(channel) do
+      pid when is_pid(pid) -> pid
+      :noproc -> :noproc
     end
   end
 end

--- a/channel-sender/mix.exs
+++ b/channel-sender/mix.exs
@@ -4,7 +4,7 @@ defmodule ChannelSenderEx.MixProject do
   def project do
     [
       app: :channel_sender_ex,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/channel-sender/test/channel_sender_ex/application_config_test.exs
+++ b/channel-sender/test/channel_sender_ex/application_config_test.exs
@@ -1,6 +1,5 @@
 defmodule ChannelSenderEx.ApplicationConfigTest do
   use ExUnit.Case
-  import Mock
 
   alias ChannelSenderEx.ApplicationConfig
 


### PR DESCRIPTION
## Description

The time the channel will remain in waiting state after socket disconnection is being governed by the parameter `max_age`, which is used to define token life. 

This change proposes to define separate parameters to control how much time (if any) a channel should remain in `waiting` state depending on how the connection between client and server terminated.

## Category

- [x] Feature
- [ ] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
