### PR TITLE
feat: added fanout and batch message delivery

### DIFF
--- a/channel-sender/config/config-local.yaml
+++ b/channel-sender/config/config-local.yaml
@@ -14,7 +14,7 @@ channel_sender_ex:
 
   # max time in seconds to wait the client to send the auth token
   # before closing the channel
-  socket_idle_timeout: 30000
+  socket_idle_timeout: 90000
 
   # Specifies the maximum time (in milliseconds) that the Elixir supervisor waits 
   # for child channel processes to terminate after sending it an exit signal 
@@ -78,7 +78,7 @@ channel_sender_ex:
     # for more information about the kubernetes configuration with libcluser
 
 logger:
-  level: info
+  level: debug
 
 
 

--- a/channel-sender/docs/swagger.yaml
+++ b/channel-sender/docs/swagger.yaml
@@ -38,40 +38,78 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvalidRequest'
+                $ref: '#/components/schemas/InvalidBodyResponse'
 
   /deliver_message:
     post:
       tags:
       - /ext/channel/
-      summary: Deliver an event from a message
-      description: Deliver an event message to a previusly registered channel_ref
+      summary: Deliver an event message to a channel or group of channels
+      description: Deliver an event message to a previusly registered channel_ref, or deliver a message to all channels related to an specific app_ref or user_ref
       operationId: deliverMessage
       requestBody:
         description: "Triggers internal workflow to deliver message. The message may not be delivered immediately, or not at all. Depends if the channel_ref was previusly registered. The message_data schema is not enforced, but its recommeded to use CloudEvents."
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Message'
+              oneOf:
+                - $ref: '#/components/schemas/Message'
+                - $ref: '#/components/schemas/AppMessage'
+                - $ref: '#/components/schemas/UserMessage'
       responses:
         "202":
           description: Ok
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    type: string
-                    example: Ok
+                $ref: '#/components/schemas/SuccessResponse'
         "400":
           description: Bad request due to invalid body or missing required fields
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvalidRequest'          
+                $ref: '#/components/schemas/InvalidBodyResponse'       
+
+  /deliver_batch:
+    post:
+      tags:
+      - /ext/channel/
+      summary: Batch deliver up to 10 event messages
+      description: Deliver event messages to a group of channel_refs
+      operationId: deliverBatchMessages
+      requestBody:
+        description: ""
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Messages'
+      responses:
+        "202":
+          description: If all messages were accepted SuccessResponse is returned. If some messages were rejected PartialSuccessResponse is returned.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - $ref: '#/components/schemas/PartialSuccessResponse'
+        "400":
+          description: Bad request due to invalid body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidBodyResponse'   
+
 components:
   schemas:
+    Messages:
+      type: object
+      required:
+        - messages
+      properties:
+        messages:
+          type: array
+          items: 
+            $ref: '#/components/schemas/Message'  
     Message:
       required:
       - channel_ref
@@ -97,6 +135,56 @@ components:
         event_name:
           type: string
           example: event.productCreated
+    AppMessage:
+      required:
+      - app_ref
+      - event_name
+      - message_data
+      - message_id
+      type: object
+      properties:
+        app_ref:
+          type: string
+          example: app01
+        message_id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        correlation_id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        message_data:
+          type: object
+          example: {"product_id": "1234", "product_name": "product name"}
+        event_name:
+          type: string
+          example: event.productCreated          
+    UserMessage:
+      required:
+      - user_ref
+      - event_name
+      - message_data
+      - message_id
+      type: object
+      properties:
+        user_ref:
+          type: string
+          example: user.1
+        message_id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        correlation_id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        message_data:
+          type: object
+          example: {"product_id": "1234", "product_name": "product name"}
+        event_name:
+          type: string
+          example: event.productCreated              
     ChannelRequest:
       required:
       - application_ref
@@ -121,7 +209,29 @@ components:
         channel_secret:
           type: string
           example: SFMyNTY.g2gDaANtAAAAQWJlZWM2MzQ1MDNjMjM4ZjViODRmNzM3Mjc1YmZkNGJhLjg1NWI4MTkzYmI2ZjQxOTM4MWVhYzZjYzA4N2FlYTNmbQAAAAZ4eHh4eHhtAAAAB3h4eHh4eHhuBgDbcXMIlAFiAAFRgA.......
-    InvalidRequest:
+    SuccessResponse:
+      type: object
+      properties:
+        result:
+          type: string
+          example: Ok
+    PartialSuccessResponse:
+      type: object
+      properties:
+        result:
+          type: string
+          example: partial-success
+        accepted_messages:
+          type: integer
+          example: 5
+        rejected_messages:
+          type: integer
+          example: 2
+        discarded:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'            
+    InvalidBodyResponse:
       required:
       - error
       - request

--- a/channel-sender/docs/swagger.yaml
+++ b/channel-sender/docs/swagger.yaml
@@ -15,10 +15,10 @@ paths:
   /create:
     post:
       tags:
-      - /ext/channel/
+      - /ext/channel
       summary: Create Channel and session
       description: |
-        By passing in the appropriate options, you can regisster a new channel in the system
+        By passing in the appropriate options, you can register a new channel in the system
       operationId: createChannel
       requestBody:
         description: Channel to create
@@ -43,7 +43,7 @@ paths:
   /deliver_message:
     post:
       tags:
-      - /ext/channel/
+      - /ext/channel
       summary: Deliver an event message to a channel or group of channels
       description: Deliver an event message to a previusly registered channel_ref, or deliver a message to all channels related to an specific app_ref or user_ref
       operationId: deliverMessage
@@ -73,7 +73,7 @@ paths:
   /deliver_batch:
     post:
       tags:
-      - /ext/channel/
+      - /ext/channel
       summary: Batch deliver up to 10 event messages
       description: Deliver event messages to a group of channel_refs
       operationId: deliverBatchMessages
@@ -98,7 +98,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InvalidBodyResponse'   
-
+  /: 
+    delete:
+      tags:
+      - /ext/channel
+      summary: Perform a graceful shutdown of a channel processes 
+      description: Perform a graceful shutdown of a channel process and related socket process, if any.
+      operationId: stopChannel
+      parameters:
+        - name: channel_ref
+          in: query
+          description: The channel_ref to be stopped
+          required: true
+          schema:
+            type: string
+            example: beec634503c238f5b84f737275bfd4ba.855b8193bb6f419381eac6cc087aea3f
+      responses:
+        "200":
+          description: If the operation is performed succesfully.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad request due to missing required parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidBodyResponse'
+                                 
 components:
   schemas:
     Messages:

--- a/channel-sender/lib/channel_sender_ex/core/channel.ex
+++ b/channel-sender/lib/channel_sender_ex/core/channel.ex
@@ -31,7 +31,8 @@ defmodule ChannelSenderEx.Core.Channel do
             pending_sending: ChannelSenderEx.Core.Channel.pending_sending(),
             stop_cause: atom(),
             socket_stop_cause: atom(),
-            user_ref: String.t()
+            user_ref: String.t(),
+            meta: String.t()
           }
 
     defstruct channel: "",
@@ -41,9 +42,10 @@ defmodule ChannelSenderEx.Core.Channel do
               pending_sending: BoundedMap.new(),
               stop_cause: nil,
               socket_stop_cause: nil,
-              user_ref: ""
+              user_ref: "",
+              meta: nil
 
-    def new(channel, application, user_ref) do
+    def new(channel, application, user_ref, meta) do
       %Data{
         channel: channel,
         application: application,
@@ -52,7 +54,8 @@ defmodule ChannelSenderEx.Core.Channel do
         pending_sending: BoundedMap.new(),
         stop_cause: nil,
         socket_stop_cause: nil,
-        user_ref: user_ref
+        user_ref: user_ref,
+        meta: meta
       }
     end
 
@@ -73,6 +76,13 @@ defmodule ChannelSenderEx.Core.Channel do
   end
 
   @doc """
+  get information about this channel
+  """
+  def info(server, timeout \\ @on_connected_channel_reply_timeout) do
+    GenStateMachine.call(server, :info, timeout)
+  end
+
+  @doc """
   operation to mark a message as acknowledged
   """
   def notify_ack(server, ref, message_id) do
@@ -89,18 +99,23 @@ defmodule ChannelSenderEx.Core.Channel do
     )
   end
 
+  def stop(server) do
+    GenStateMachine.call(server, :stop)
+  end
+
   @spec start_link(any()) :: :gen_statem.start_ret()
   @doc """
   Starts the state machine.
   """
-  def start_link(args = {_channel, _application, _user_ref}, opts \\ []) do
+  def start_link(args = {_channel, _application, _user_ref, _meta}, opts \\ []) do
     GenStateMachine.start_link(__MODULE__, args, opts)
   end
 
   @impl GenStateMachine
   @doc false
-  def init({channel, application, user_ref}) do
-    data = Data.new(channel, application, user_ref)
+  def init({channel, application, user_ref, meta}) do
+    data = Data.new(channel, application, user_ref, meta)
+    Logger.debug("Channel #{channel} created. Data: #{inspect(data)}")
     Process.flag(:trap_exit, true)
     CustomTelemetry.execute_custom_event([:adf, :channel], %{count: 1})
     {:ok, :waiting, data}
@@ -121,6 +136,21 @@ defmodule ChannelSenderEx.Core.Channel do
         new_data = %{data | socket_stop_cause: nil}
         {:keep_state, new_data, [{:state_timeout, waiting_timeout, :waiting_timeout}]}
     end
+  end
+
+  def waiting({:call, from}, :info, data) do
+    actions = [
+      _reply = {:reply, from, {:waiting, data}}
+    ]
+    {:keep_state_and_data, actions}
+  end
+
+  def waiting({:call, from}, :stop, data) do
+    actions = [
+      _reply = {:reply, from, :ok}
+    ]
+    Logger.info("Channel #{data.channel} stopping, reason: :explicit_close")
+    {:next_state, :closed, %{data | stop_cause: :explicit_close}, actions}
   end
 
   ## stop the process with a timeout cause if the socket is not
@@ -203,6 +233,24 @@ defmodule ChannelSenderEx.Core.Channel do
     refresh_timeout = calculate_refresh_token_timeout()
     Logger.info("Channel #{data.channel} entering connected state")
     {:keep_state_and_data, [{:state_timeout, refresh_timeout, :refresh_token_timeout}]}
+  end
+
+  def connected({:call, from}, :info, data) do
+    actions = [
+      _reply = {:reply, from, {:connected, data}}
+    ]
+    {:keep_state_and_data, actions}
+  end
+
+  def connected({:call, from}, {:socket_connected, socket_pid}, data) do
+    socket_ref = Process.monitor(socket_pid)
+    new_data = %{data | socket: {socket_pid, socket_ref}, socket_stop_cause: nil}
+
+    actions = [
+      _reply = {:reply, from, :ok}
+    ]
+    Logger.debug("Channel #{data.channel} overwritting socket pid.")
+    {:keep_state, new_data, actions}
   end
 
   # this method will be called when the socket is disconnected
@@ -304,8 +352,8 @@ defmodule ChannelSenderEx.Core.Channel do
 
   ## Handle info notification when socket process terminates. This method is called because the socket is monitored.
   ## via Process.monitor(socket_pid) in the waited/connected state.
-  def connected(:info, {:DOWN, _ref, :process, _object, _reason}, data) do
-    new_data = %{data | socket: nil}
+  def connected(:info, {:DOWN, _ref, :process, _object, reason}, data) do
+    new_data = %{data | socket: nil, socket_stop_cause: reason}
     Logger.warning("Channel #{data.channel} detected socket close/disconnection. Will enter :waiting state")
     {:next_state, :waiting, new_data, []}
   end
@@ -321,6 +369,14 @@ defmodule ChannelSenderEx.Core.Channel do
     {:stop, :normal, %{data | stop_cause: :name_conflict}}
   end
 
+  # capture shutdown signal
+  def connected(:info, {:EXIT, from_pid, :shutdown}, data) do
+    source_process = Process.info(from_pid)
+    Logger.info("Channel #{inspect(data)} received shutdown signal: #{inspect(source_process)}")
+    :keep_state_and_data
+  end
+
+  # capture any other info message
   def connected(
     :info,
     info_payload,
@@ -330,17 +386,36 @@ defmodule ChannelSenderEx.Core.Channel do
     {:keep_state_and_data, :postpone}
   end
 
-  @impl true
-  def terminate(reason, state, data) do
-    CustomTelemetry.execute_custom_event([:adf, :channel], %{count: -1})
-    level = if reason == :normal, do: :info, else: :warning
-    Logger.log(level, "Channel #{data.channel} terminating, from state #{inspect(state)} and reason #{inspect(reason)}")
-    :ok
+  def connected({:call, from}, :stop, data) do
+    actions = [
+      _reply = {:reply, from, :ok}
+    ]
+    Logger.debug("Channel #{data.channel} stopping, reason: :explicit_close")
+    {:next_state, :closed, %{data | stop_cause: :explicit_close}, actions}
   end
 
   defp new_token_message(_data = %{application: app, channel: channel, user_ref: user}) do
     new_token = ChannelIDGenerator.generate_token(channel, app, user)
     ProtocolMessage.of(UUID.uuid4(:hex), ":n_token", new_token)
+  end
+
+  ############################################
+  ###           CLOSED STATE              ####
+  ############################################
+  def closed(:enter, _old_state, data) do
+    {:stop, :normal, data}
+  end
+
+  @impl true
+  def terminate(reason, state, data) do
+    CustomTelemetry.execute_custom_event([:adf, :channel], %{count: -1})
+    level = if reason == :normal, do: :info, else: :warning
+    Logger.log(level,
+    """
+    Channel #{data.channel} terminating, from state #{inspect(state)}
+    and reason #{inspect(reason)}. Data: #{inspect(data)}
+    """)
+    :ok
   end
 
   #########################################
@@ -430,6 +505,7 @@ defmodule ChannelSenderEx.Core.Channel do
 
   defp socket_clean_disconnection?(data) do
     case data.socket_stop_cause do
+      :normal -> true
       {:remote, 1000, _} -> true
       _ -> false
     end

--- a/channel-sender/lib/channel_sender_ex/core/channel.ex
+++ b/channel-sender/lib/channel_sender_ex/core/channel.ex
@@ -17,6 +17,7 @@ defmodule ChannelSenderEx.Core.Channel do
   @type output_message() :: {delivery_ref(), ProtocolMessage.t()}
   @type pending_ack() :: BoundedMap.t()
   @type pending_sending() :: BoundedMap.t()
+  @type deliver_response :: :accepted_waiting | :accepted_connected
 
   defmodule Data do
     @moduledoc """
@@ -81,7 +82,6 @@ defmodule ChannelSenderEx.Core.Channel do
   @doc """
   operation to request a message delivery
   """
-  @type deliver_response :: :accepted_waiting | :accepted_connected
   @spec deliver_message(:gen_statem.server_ref(), ProtocolMessage.t()) :: deliver_response()
   def deliver_message(server, message) do
     GenStateMachine.call(server, {:deliver_message, message},

--- a/channel-sender/lib/channel_sender_ex/core/channel_registry.ex
+++ b/channel-sender/lib/channel_sender_ex/core/channel_registry.ex
@@ -5,6 +5,9 @@ defmodule ChannelSenderEx.Core.ChannelRegistry do
   use Horde.Registry
   require Logger
 
+  @type channel_ref :: String.t()
+  @type channel_addr :: pid()
+
   def start_link(_) do
     Horde.Registry.start_link(__MODULE__, [keys: :unique], name: __MODULE__)
   end
@@ -17,8 +20,6 @@ defmodule ChannelSenderEx.Core.ChannelRegistry do
     result
   end
 
-  @type channel_ref :: String.t()
-  @type channel_addr :: pid()
   @spec lookup_channel_addr(channel_ref()) :: :noproc | channel_addr()
   @compile {:inline, lookup_channel_addr: 1}
   def lookup_channel_addr(channel_ref) do
@@ -26,6 +27,26 @@ defmodule ChannelSenderEx.Core.ChannelRegistry do
       [{pid, _}] -> pid
       [] -> :noproc
     end
+  end
+
+  @spec query_by_app(String.t()) :: Enumerable.t()
+  def query_by_app(app) do
+    # select pattern is: $1 = channel_ref, $2 = pid, $3 = app_ref, $4 = user_ref
+    # guard condition is to match $3 with app ref
+    # return $2 which is the pid of the process
+    Stream.map(Horde.Registry.select(__MODULE__, [
+      {{:"$1", :"$2", {:"$3", :"$4"}}, [{:==, :"$3", app}], [:"$2"]}
+      ]), fn pid -> pid end)
+  end
+
+  @spec query_by_user(String.t()) :: Enumerable.t()
+  def query_by_user(user) do
+    # select pattern is: $1 = channel_ref, $2 = pid, $3 = app_ref, $4 = user_ref
+    # guard condition is to match $4 with user ref
+    # return $2 which is the pid of the process
+    Stream.map(Horde.Registry.select(__MODULE__, [
+      {{:"$1", :"$2", {:"$3", :"$4"}}, [{:==, :"$4", user}], [:"$2"]}
+      ]), fn pid -> pid end)
   end
 
   @compile {:inline, via_tuple: 1}
@@ -37,10 +58,4 @@ defmodule ChannelSenderEx.Core.ChannelRegistry do
     Enum.map([Node.self() | Node.list()], &{__MODULE__, &1})
   end
 
-#  def lookup_channel_addr(channel_ref, registry) do
-#    case @registry_module.lookup(via_tuple(channel_ref, registry)) do
-#      [{pid, _}] -> pid
-#      [] -> :noproc
-#    end
-#  end
 end

--- a/channel-sender/lib/channel_sender_ex/core/channel_supervisor.ex
+++ b/channel-sender/lib/channel_sender_ex/core/channel_supervisor.ex
@@ -35,8 +35,8 @@ defmodule ChannelSenderEx.Core.ChannelSupervisor do
 
   @spec channel_child_spec(channel_init_args()) :: any()
   @compile {:inline, channel_child_spec: 1}
-  def channel_child_spec(channel_args = {channel_ref, _application, _user_ref}) do
-    channel_child_spec(channel_args, via_tuple(channel_ref))
+  def channel_child_spec(channel_args = {channel_ref, application, user_ref}) do
+    channel_child_spec(channel_args, via_tuple(channel_ref, application, user_ref))
   end
 
   @compile {:inline, channel_child_spec: 2}
@@ -49,8 +49,8 @@ defmodule ChannelSenderEx.Core.ChannelSupervisor do
     }
   end
 
-  defp via_tuple(name) do
-    {:via, Horde.Registry, {ChannelSenderEx.Core.ChannelRegistry, name}}
+  defp via_tuple(ref, app, usr) do
+    {:via, Horde.Registry, {ChannelSenderEx.Core.ChannelRegistry, ref, {app, usr}}}
   end
 
   defp get_shutdown_tolerance do

--- a/channel-sender/lib/channel_sender_ex/core/channel_supervisor.ex
+++ b/channel-sender/lib/channel_sender_ex/core/channel_supervisor.ex
@@ -27,7 +27,9 @@ defmodule ChannelSenderEx.Core.ChannelSupervisor do
   @type channel_ref :: String.t()
   @type application :: String.t()
   @type user_ref :: String.t()
-  @type channel_init_args :: {channel_ref(), application(), user_ref()}
+  @type meta :: list()
+  @type channel_init_args :: {channel_ref(), application(), user_ref(), meta()}
+
   @spec start_channel(channel_init_args()) :: any()
   def start_channel(args) do
     Horde.DynamicSupervisor.start_child(__MODULE__, channel_child_spec(args))
@@ -35,12 +37,12 @@ defmodule ChannelSenderEx.Core.ChannelSupervisor do
 
   @spec channel_child_spec(channel_init_args()) :: any()
   @compile {:inline, channel_child_spec: 1}
-  def channel_child_spec(channel_args = {channel_ref, application, user_ref}) do
+  def channel_child_spec(channel_args = {channel_ref, application, user_ref, _meta}) do
     channel_child_spec(channel_args, via_tuple(channel_ref, application, user_ref))
   end
 
   @compile {:inline, channel_child_spec: 2}
-  def channel_child_spec(channel_args = {channel_ref, _application, _user_ref}, name) do
+  def channel_child_spec(channel_args = {channel_ref, _application, _user_ref, _meta}, name) do
     %{
       id: "Channel_#{channel_ref}",
       start: {Channel, :start_link, [channel_args, [name: name]]},

--- a/channel-sender/lib/channel_sender_ex/core/pubsub/pub_sub_core.ex
+++ b/channel-sender/lib/channel_sender_ex/core/pubsub/pub_sub_core.ex
@@ -22,7 +22,7 @@ defmodule ChannelSenderEx.Core.PubSub.PubSubCore do
   Delivers a message to a single channel associated with the given channel reference.
   If the channel is not found, the message is retried up to @max_retries times with exponential backoff.
   """
-  @spec deliver_to_channel(channel_ref(), ProtocolMessage.t()) :: Channel.deliver_response()
+  @spec deliver_to_channel(channel_ref(), ProtocolMessage.t()) :: any()
   def deliver_to_channel(channel_ref, message) do
     action_fn = fn _ -> do_deliver_to_channel(channel_ref, message) end
     execute(@min_backoff, @max_backoff, @max_retries, action_fn, fn ->
@@ -65,4 +65,12 @@ defmodule ChannelSenderEx.Core.PubSub.PubSubCore do
     end
   end
 
+  def delete_channel(channel_ref) do
+    case ChannelRegistry.lookup_channel_addr(channel_ref) do
+      pid when is_pid(pid) ->
+        Channel.stop(pid)
+      :noproc ->
+        :noproc
+    end
+  end
 end

--- a/channel-sender/lib/channel_sender_ex/core/pubsub/pub_sub_core.ex
+++ b/channel-sender/lib/channel_sender_ex/core/pubsub/pub_sub_core.ex
@@ -11,12 +11,18 @@ defmodule ChannelSenderEx.Core.PubSub.PubSubCore do
   import ChannelSenderEx.Core.Retry.ExponentialBackoff, only: [execute: 5]
 
   @type channel_ref() :: String.t()
+  @type app_ref() :: String.t()
+  @type delivery_result() :: %{accepted_waiting: number(), accepted_connected: number()}
 
   @max_retries 10
   @min_backoff 50
   @max_backoff 2000
 
-  @spec deliver_to_channel(channel_ref(), ProtocolMessage.t()) :: any()
+  @doc """
+  Delivers a message to a single channel associated with the given channel reference.
+  If the channel is not found, the message is retried up to @max_retries times with exponential backoff.
+  """
+  @spec deliver_to_channel(channel_ref(), ProtocolMessage.t()) :: Channel.deliver_response()
   def deliver_to_channel(channel_ref, message) do
     action_fn = fn _ -> do_deliver_to_channel(channel_ref, message) end
     execute(@min_backoff, @max_backoff, @max_retries, action_fn, fn ->
@@ -27,6 +33,28 @@ defmodule ChannelSenderEx.Core.PubSub.PubSubCore do
     e ->
       Logger.warning("Could not deliver message after #{@max_retries} retries, to channel: \"#{channel_ref}\". Cause: #{inspect(e)}")
       :error
+  end
+
+  @doc """
+  Delivers a message to all channels associated with the given application reference. The message is delivered to each channel in a separate process.
+  No retries are performed since the message is delivered to existing and queriyable channels at the given time.
+  """
+  @spec deliver_to_app_channels(app_ref(), ProtocolMessage.t()) :: delivery_result()
+  def deliver_to_app_channels(app_ref, message) do
+    ChannelRegistry.query_by_app(app_ref)
+    |> Stream.map(fn pid -> Channel.deliver_message(pid, message) end)
+    |> Enum.frequencies()
+  end
+
+  @doc """
+  Delivers a message to all channels associated with the given user reference. The message is delivered to each channel in a separate process.
+  No retries are performed since the message is delivered to existing and queriyable channels at the given time.
+  """
+  @spec deliver_to_user_channels(app_ref(), ProtocolMessage.t()) :: delivery_result()
+  def deliver_to_user_channels(user_ref, message) do
+    ChannelRegistry.query_by_user(user_ref)
+    |> Stream.map(fn pid -> Channel.deliver_message(pid, message) end)
+    |> Enum.frequencies()
   end
 
   defp do_deliver_to_channel(channel_ref, message) do

--- a/channel-sender/lib/channel_sender_ex/core/pubsub/re_connect_process.ex
+++ b/channel-sender/lib/channel_sender_ex/core/pubsub/re_connect_process.ex
@@ -37,6 +37,7 @@ defmodule ChannelSenderEx.Core.PubSub.ReConnectProcess do
         timeout = Application.get_env(:channel_sender_ex,
                             :on_connected_channel_reply_timeout)
         Channel.socket_connected(pid, socket_pid, timeout)
+        pid
     end
   catch
     _type, _err -> :noproc

--- a/channel-sender/lib/channel_sender_ex/core/security/channel_authenticator.ex
+++ b/channel-sender/lib/channel_sender_ex/core/security/channel_authenticator.ex
@@ -9,11 +9,12 @@ defmodule ChannelSenderEx.Core.Security.ChannelAuthenticator do
   @type user_ref() :: String.t()
   @type channel_ref() :: String.t()
   @type channel_secret() :: String.t()
+  @type meta() :: list()
 
-  @spec create_channel(application(), user_ref()) :: {channel_ref(), channel_secret()}
-  def create_channel(application, user_ref) do
+  @spec create_channel(application(), user_ref(), meta()) :: {channel_ref(), channel_secret()}
+  def create_channel(application, user_ref, meta \\ []) do
     {channel_ref, _channel_secret} = credentials = create_channel_data_for(application, user_ref)
-    {:ok, _pid} = ChannelSupervisor.start_channel({channel_ref, application, user_ref})
+    {:ok, _pid} = ChannelSupervisor.start_channel({channel_ref, application, user_ref, meta})
     credentials
   end
 

--- a/channel-sender/lib/channel_sender_ex/transport/cowboy_starter.ex
+++ b/channel-sender/lib/channel_sender_ex/transport/cowboy_starter.ex
@@ -33,7 +33,12 @@ defmodule ChannelSenderEx.Transport.CowboyStarter do
         CustomTelemetry.execute_custom_event([:adf, :socket, :switchprotocol],
           %{count: 1},
           %{request_path: "/ext/socket", status: 101, code: "0"})
+      _ ->
+        :ok
     end
+
+  rescue
+    e -> Logger.warning("Error in metrics callback: #{inspect(e)}")
   end
 
   defp compile_routes(paths) do

--- a/channel-sender/lib/channel_sender_ex/transport/rest/rest_controller.ex
+++ b/channel-sender/lib/channel_sender_ex/transport/rest/rest_controller.ex
@@ -23,6 +23,7 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
   get("/health", do: send_resp(conn, 200, "UP"))
   post("/ext/channel/create", do: create_channel(conn))
   post("/ext/channel/deliver_message", do: deliver_message(conn))
+  post("/ext/channel/deliver_batch", do: deliver_message(conn))
   match(_, do: send_resp(conn, 404, "Route not found."))
 
   defp create_channel(conn) do
@@ -60,6 +61,20 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
     route_deliver(conn.body_params, conn)
   end
 
+  defp route_deliver(_body = %{
+    messages: messages
+    }, conn) do
+
+    # takes N first messages and separates them into valid and invalid messages
+    {valid_messages, invalid_messages} = batch_separate_messages(messages)
+
+    valid_messages
+    |> perform_delivery
+
+    batch_build_response({valid_messages, invalid_messages}, messages, conn)
+
+  end
+
   defp route_deliver(
     message = %{
       channel_ref: channel_ref,
@@ -69,9 +84,52 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
       event_name: _event_name
      }, conn
    ) do
+    assert_deliver_request(message)
+    |> perform_delivery(%{"channel_ref" => channel_ref})
+    |> build_and_send_response(conn)
+  end
 
-    # assert that minimum required fields are present
-    is_valid = message
+  defp route_deliver(
+        message = %{
+          app_ref: app_ref,
+          message_id: _message_id,
+          correlation_id: _correlation_id,
+          message_data: _message_data,
+          event_name: _event_name
+        }, conn
+      ) do
+
+    assert_deliver_request(message)
+    |> perform_delivery(%{"app_ref" => app_ref})
+    |> build_and_send_response(conn)
+
+  end
+
+  defp route_deliver(
+    message = %{
+      user_ref: user_ref,
+      message_id: _message_id,
+      correlation_id: _correlation_id,
+      message_data: _message_data,
+      event_name: _event_name
+    }, conn
+  ) do
+
+    assert_deliver_request(message)
+    |> perform_delivery(%{"user_ref" => user_ref})
+    |> build_and_send_response(conn)
+
+  end
+
+  defp route_deliver(_, conn), do: invalid_body(conn)
+
+  #"""
+  # Asserts that the message is a valid delivery request
+  #"""
+  @spec assert_deliver_request(map()) :: {:ok, map()} | {:error, :invalid_message}
+  defp assert_deliver_request(message) do
+    # Check if minimal fields are present and not nil
+    result = message
     |> Enum.all?(fn {key, value} ->
       case key do
         :message_data ->
@@ -83,21 +141,123 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
       end
     end)
 
-    case is_valid do
+    case result do
       true ->
-        Task.start(fn -> PubSubCore.deliver_to_channel(channel_ref,
-          Map.drop(message, [:channel_ref]) |> ProtocolMessage.to_protocol_message)
-        end)
-        conn
-        |> put_resp_header("content-type", "application/json")
-        |> send_resp(202, Jason.encode!(%{result: "Ok"}))
-
+        {:ok, message}
       false ->
-        invalid_body(conn)
+        {:error, :invalid_message}
     end
   end
 
-  defp route_deliver(_, conn), do: invalid_body(conn)
+  defp perform_delivery(messages) when is_list(messages) do
+    Enum.map(messages, fn message ->
+      Task.start(fn ->
+        {channel_ref, new_msg} = Map.pop(message, :channel_ref)
+        PubSubCore.deliver_to_channel(channel_ref, ProtocolMessage.to_protocol_message(new_msg))
+      end)
+    end)
+  end
+
+  defp perform_delivery({:ok, message}, %{"channel_ref" => channel_ref}) do
+    Task.start(fn ->
+      new_msg = message
+      |> Map.drop([:channel_ref])
+      |> ProtocolMessage.to_protocol_message
+
+      PubSubCore.deliver_to_channel(channel_ref, new_msg)
+    end)
+    {202, %{result: "Ok"}}
+  end
+
+  defp perform_delivery({:ok, message}, %{"app_ref" => app_ref}) do
+    Task.start(fn ->
+      new_msg = message
+      |> Map.drop([:app_ref])
+      |> ProtocolMessage.to_protocol_message
+      PubSubCore.deliver_to_app_channels(app_ref, new_msg)
+    end)
+
+    {202, %{result: "Ok"}}
+  end
+
+  defp perform_delivery({:ok, message}, %{"user_ref" => user_ref}) do
+    Task.start(fn ->
+      new_msg = message
+      |> Map.drop([:user_ref])
+      |> ProtocolMessage.to_protocol_message
+      PubSubCore.deliver_to_user_channels(user_ref, new_msg)
+    end)
+
+    {202, %{result: "Ok"}}
+  end
+
+  defp perform_delivery(e = {:error, :invalid_message}, _) do
+    {400, e}
+  end
+
+  @spec batch_separate_messages([map()]) :: {[map()], [map()]}
+  defp batch_separate_messages(messages) do
+    {valid, invalid} = Enum.take(messages, 10)
+    |> Enum.map(fn message ->
+      case assert_deliver_request(message) do
+        {:ok, _} ->
+          {:ok, message}
+        {:error, _} ->
+          {:error, {message, :invalid_message}}
+      end
+    end)
+    |> Enum.split_with(fn {outcome, _detail} -> case outcome do
+        :ok -> true
+        :error -> false
+      end
+    end)
+
+    {
+      Enum.map(valid, fn {:ok, message} -> message end),
+      Enum.map(invalid, fn {:error, {message, _}} -> message end)
+    }
+  end
+
+  defp batch_build_response({valid, invalid}, messages, conn) do
+    original_size = length(messages)
+    l_valid = length(valid)
+    l_invalid = length(invalid)
+    case {l_valid, l_invalid} do
+      {0, 0} ->
+        build_and_send_response({400, nil}, conn)
+      {0, i} when i > 0 ->
+        build_and_send_response({400, %{result: "invalid-messages",
+        accepted_messages: 0,
+        discarded_messages: i,
+        discarded: invalid}}, conn)
+      {v, 0} ->
+        procesed = l_valid + l_invalid
+        discarded = original_size - procesed
+        msg = case discarded do
+          0 -> %{result: "Ok"}
+          _ -> %{result: "partial-success",
+            accepted_messages: v,
+            discarded_messages: discarded,
+            discarded: Enum.drop(messages, 10)}
+        end
+        build_and_send_response({202, msg}, conn)
+      {v, i} ->
+        build_and_send_response({202, %{result: "partial-success",
+          accepted_messages: v,
+          discarded_messages: i,
+          discarded: invalid}}, conn)
+    end
+  end
+
+  defp build_and_send_response({202, body}, conn) do
+    conn
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(202, Jason.encode!(body))
+  end
+
+  defp build_and_send_response({400, _}, conn) do
+    invalid_body(conn)
+  end
 
   @compile {:inline, invalid_body: 1}
   defp invalid_body(conn = %{body_params: invalid_body}) do
@@ -105,4 +265,5 @@ defmodule ChannelSenderEx.Transport.Rest.RestController do
     |> put_resp_header("content-type", "application/json")
     |> send_resp(400, Jason.encode!(%{error: "Invalid request", request: invalid_body}))
   end
+
 end

--- a/channel-sender/lib/channel_sender_ex/transport/socket.ex
+++ b/channel-sender/lib/channel_sender_ex/transport/socket.ex
@@ -5,17 +5,35 @@ defmodule ChannelSenderEx.Transport.Socket do
   @behaviour :cowboy_websocket
   @channel_key "channel"
 
-  # Error code to indicate a generic bad request
-  @invalid_request_code "1006"
+  @normal_close_code "3000"
+
+  ## ---------------------
+  ## Non-Retryable errors
+  ## ---------------------
+
+  # Error code to indicate a generic bad request.
+  @invalid_request_code "3006"
+
+  # Error to indicate the shared secret for the channel is invalid
+  @invalid_secret_code "3008"
+
+  # Error code to indicate that the channel is already connected
+  # and a new socket process is trying to connect to it.
+  @invalid_already_stablished "3009"
+
+  ## -----------------
+  ## Retryable errors
+  ## -----------------
 
   # Error code to indicate bad request, specifically when
-  # not providing a valid channel reference
-  @invalid_channel_code "1007"
-
-  @invalid_secret_code 1008
+  # not providing a valid channel reference, or when clustered
+  # the reference its yet visible among all replicas.
+  # This error code and up, may be retried by the client.
+  @invalid_channel_code "3050"
 
   require Logger
 
+  alias ChannelSenderEx.Core.Channel
   alias ChannelSenderEx.Core.ChannelRegistry
   alias ChannelSenderEx.Core.ProtocolMessage
   alias ChannelSenderEx.Core.PubSub.ReConnectProcess
@@ -42,7 +60,6 @@ defmodule ChannelSenderEx.Transport.Socket do
   @impl :cowboy_websocket
   def init(req = %{method: "GET"}, opts) do
     init_result = get_relevant_request_info(req)
-      |> lookup_channel_addr
       |> process_subprotocol_selection(req)
 
     case init_result do
@@ -54,75 +71,26 @@ defmodule ChannelSenderEx.Transport.Socket do
     end
   end
 
-  defp get_relevant_request_info(req) do
-    # extracts the channel key from the request query string
-    case :lists.keyfind(@channel_key, 1, :cowboy_req.parse_qs(req)) do
-      {@channel_key, channel} = resp when byte_size(channel) > 10 ->
-        Logger.debug("Socket starting, parameters: #{inspect(resp)}")
-        resp
-      _ ->
-        Logger.error("Socket unable to start. channel_ref not found in query string request.")
-        {:error, @invalid_request_code}
-    end
-  end
-
-  defp lookup_channel_addr(channel_ref) do
-    action_fn = fn _ -> check_channel_registered(channel_ref) end
-    # retries 3 times the lookup of the channel reference (useful when running as a cluster with several nodes)
-    # with a backoff strategy of 100ms initial delay and max of 500ms delay.
-    execute(50, 300, 3, action_fn, fn ->
-      Logger.error("Socket unable to start. channel_ref process does not exist yet, ref: #{inspect(channel_ref)}")
-      {:error, @invalid_channel_code}
-    end)
-  end
-
-  defp check_channel_registered(res = {@channel_key, channel_ref}) do
-    case ChannelRegistry.lookup_channel_addr(channel_ref) do
-      :noproc ->
-        Logger.warning("Channel #{channel_ref} not found, retrying query...")
-        :retry
-      _ -> res
-    end
-  end
-
-  defp check_channel_registered(res = {:error, _desc}) do
-    res
-  end
-
-  defp process_subprotocol_selection({@channel_key, channel}, req) do
-    case :cowboy_req.parse_header("sec-websocket-protocol", req) do
-      :undefined ->
-        {:cowboy_websocket, req, _state = {channel, :pre_auth, Application.get_env(
-          :channel_sender_ex,
-          :message_encoder,
-          ChannelSenderEx.Transport.Encoders.JsonEncoder
-          )}, ws_opts()}
-
-      sub_protocols ->
-        {encoder, req} =
-          case Enum.member?(sub_protocols, "binary_flow") do
-            true ->
-              {BinaryEncoder,
-               :cowboy_req.set_resp_header("sec-websocket-protocol", "binary_flow", req)}
-
-            false ->
-              {JsonEncoder,
-               :cowboy_req.set_resp_header("sec-websocket-protocol", "json_flow", req)}
-          end
-
-        {:cowboy_websocket, req, _state = {channel, :pre_auth, encoder}, ws_opts()}
-    end
-  end
-
-  defp process_subprotocol_selection(err = {:error, _}, _req) do
-    Logger.error("Socket unable to start. Error: #{inspect(err)}")
-    err
-  end
-
   @impl :cowboy_websocket
   def websocket_init(state) do
-    Logger.debug("Socket init #{inspect(state)}")
-    {_commands = [], state}
+    Logger.debug("Socket init with pid: #{inspect(self())} starting... #{inspect(state)}")
+    {ref, _, _} = state
+    proc = lookup_channel_addr({"channel", ref})
+    case proc do
+      {:ok, pid} ->
+        case validate_channel_is_waiting(pid) do
+          {:error, desc, data} ->
+            Logger.warning("""
+            Socket init with pid: #{inspect(self())} will not continue for #{ref}.
+            Error: #{desc}. There is a socket already connected = #{inspect(data.socket)}
+            """)
+            {_commands = [{:close, 1001, desc}], state}
+          _ ->
+            {_commands = [], state}
+        end
+      {:error, desc} ->
+        {_commands = [{:close, 1001, desc}], state}
+    end
   end
 
   @impl :cowboy_websocket
@@ -143,7 +111,7 @@ defmodule ChannelSenderEx.Transport.Socket do
         %{request_path: "/ext/socket", status: 101, code: @invalid_secret_code})
 
         Logger.error("Socket unable to authorize connection. Error: #{@invalid_secret_code}-invalid token for channel #{channel}")
-        {_commands = [{:close, @invalid_secret_code, "Invalid token for channel"}],
+        {_commands = [{:close, 1001, <<@invalid_secret_code>>}],
          {channel, :unauthorized}}
     end
   end
@@ -176,26 +144,6 @@ defmodule ChannelSenderEx.Transport.Socket do
     {_commands = [], state}
   end
 
-  @compile {:inline, notify_connected: 1}
-  defp notify_connected(channel) do
-    Logger.debug("Socket for channel #{channel} connected")
-
-    socket_event_bus = get_param(:socket_event_bus, nil)
-    ch_pid = socket_event_bus.notify_event({:connected, channel}, self())
-    Process.monitor(ch_pid)
-  end
-
-  @compile {:inline, set_pending: 2}
-  defp set_pending(state, new_pending), do: :erlang.setelement(5, state, new_pending)
-
-  @compile {:inline, remove_pending: 2}
-  defp remove_pending(state = {_, :connected, _, _, pending}, message_id) do
-    case Map.pop(pending, message_id) do
-      {nil, _} -> {nil, state}
-      {elem, new_pending} -> {elem, set_pending(state, new_pending)}
-    end
-  end
-
   @impl :cowboy_websocket
   def websocket_info(
         {:deliver_msg, from = {pid, ref}, message},
@@ -214,11 +162,40 @@ defmodule ChannelSenderEx.Transport.Socket do
     end
   end
 
+  # @impl :cowboy_websocket
+  # def websocket_info({:DOWN, ref, :process, _pid, cause}, state = {channel_ref, :connected, _, {_, _, ref}, _}) do
+  #   case cause do
+  #     :normal ->
+  #       Logger.info("Socket for channel #{channel_ref}. Related process #{inspect(ref)} down normally")
+  #       {_commands = [{:close, @normal_close_code, "close"}], state}
+  #   _ ->
+  #       Logger.warning("""
+  #         Socket for channel #{channel_ref}. Related Process #{inspect(ref)}
+  #         down with cause #{inspect(cause)}. Spawning process for re-conection
+  #       """)
+  #       spawn_monitor(ReConnectProcess, :start, [self(), channel_ref])
+  #       {_commands = [], state}
+  #   end
+  # end
+
   @impl :cowboy_websocket
-  def websocket_info({:DOWN, ref, :process, _pid, _cause}, state = {channel_ref, :connected, _, {_, _, ref}, _}) do
-    Logger.warning("Socket for channel #{channel_ref} : spawning process for re-conection")
-    spawn_monitor(ReConnectProcess, :start, [self(), channel_ref])
-    {_commands = [], state}
+  def websocket_info({:DOWN, ref, proc, pid, cause}, state = {channel_ref, _, _, _, _}) do
+    case cause do
+      :normal ->
+        Logger.info("Socket for channel #{channel_ref}. Related process #{inspect(ref)} down normally.")
+        {_commands = [{:close, 1000, <<@normal_close_code>>}], state}
+      _ ->
+        Logger.warning("""
+          Socket for channel #{channel_ref}. Related Process #{inspect(ref)}
+          received DOWN message: #{inspect({ref, proc, pid, cause})}. Spawning process for re-conection
+        """)
+
+        new_pid = ReConnectProcess.start(self(), channel_ref)
+        Logger.debug("Socket for channel #{channel_ref} : channel process found for re-conection: #{inspect(new_pid)}")
+        Process.monitor(new_pid)
+
+        {_commands = [], state}
+    end
   end
 
   @impl :cowboy_websocket
@@ -229,26 +206,193 @@ defmodule ChannelSenderEx.Transport.Socket do
   end
 
   @impl :cowboy_websocket
-  def websocket_info(_message, state) do
+  def websocket_info(message, state) do
+    Logger.warning("Socket received socket info message: #{inspect(message)}, state: #{inspect(state)}")
     {_commands = [], state}
   end
 
   @impl :cowboy_websocket
-  def terminate(reason, _partial_req, state) do
+  def terminate(reason, partial_req, state) do
+
+    Logger.debug("Socket terminate with pid: #{inspect(self())}. REASON: #{inspect(reason)}. REQ: #{inspect(partial_req)}, STATE: #{inspect(state)}")
+
     CustomTelemetry.execute_custom_event([:adf, :socket, :disconnection], %{count: 1})
-    case state do
-      {channel_ref, _, _, _, _} ->
-        Logger.warning("Socket for channel #{channel_ref} terminated with reason: #{inspect(reason)}")
-        socket_event_bus = get_param(:socket_event_bus, :noop)
-        case socket_event_bus do
-          :noop -> :ok
-          _ ->
-            socket_event_bus.notify_event({:socket_down_reason, channel_ref, reason}, self())
-        end
+
+    handle_terminate(reason, partial_req, state)
+
+    # level = if reason == :normal, do: :info, else: :warning
+    # case state do
+    #   { channel_ref, _, _, _, _} ->
+    #     level = if reason == :normal, do: :info, else: :warning
+    #     Logger.log(level, "Socket for channel #{channel_ref} terminated with reason: #{inspect(reason)}")
+    #     post_terminate(reason, channel_ref)
+    #     :ok
+    #   _ ->
+    #     Logger.log(level, "Socket terminated with reason: #{reason}. State: #{inspect(state)}")
+    #     :ok
+    # end
+  end
+
+  #############################
+  ##
+  ## SUPPORT FUNCTIONS
+  ##
+  #############################
+
+  defp get_relevant_request_info(req) do
+    # extracts the channel key from the request query string
+    case :lists.keyfind(@channel_key, 1, :cowboy_req.parse_qs(req)) do
+      {@channel_key, channel} = resp when byte_size(channel) > 10 ->
+        resp
       _ ->
-        Logger.warning("Socket terminated with reason: #{reason} and state: #{inspect(state)}")
-        :ok
+        Logger.error("Socket unable to start. channel_ref not found in query string request.")
+        {:error, @invalid_request_code}
     end
+  end
+
+  defp lookup_channel_addr(channel_ref) do
+    action_fn = fn _ -> check_channel_registered(channel_ref) end
+    # retries 3 times the lookup of the channel reference (useful when running as a cluster with several nodes)
+    # with a backoff strategy of 100ms initial delay and max of 500ms delay.
+    result = execute(50, 300, 3, action_fn, fn ->
+      Logger.error("Socket unable to start. channel_ref process does not exist yet, ref: #{inspect(channel_ref)}")
+      {:error, <<@invalid_channel_code>>}
+    end)
+
+    case result do
+      {:error, _desc} = e ->
+        e
+      {pid, _res} ->
+        {:ok, pid}
+    end
+  end
+
+  defp check_channel_registered(res = {@channel_key, channel_ref}) do
+    case ChannelRegistry.lookup_channel_addr(channel_ref) do
+      :noproc ->
+        Logger.warning("Socket: #{channel_ref} not found, retrying query...")
+        :retry
+      pid ->
+        {pid, res}
+    end
+  end
+
+  # defp check_channel_registered({:error, _desc}) do
+  #   :retry
+  # end
+
+  defp validate_channel_is_waiting(pid) when is_pid(pid)  do
+    {status, data} = Channel.info(pid)
+    case status do
+      :waiting ->
+        # process can continue, and socket process will be linked to the channel process
+        {:ok, data}
+      _ ->
+        # channel is already in a connected state, and a previous socket process
+        # was already linked to it.
+        {:error, <<@invalid_already_stablished>>, data}
+    end
+  end
+
+  defp process_subprotocol_selection({@channel_key, channel}, req) do
+    case :cowboy_req.parse_header("sec-websocket-protocol", req) do
+      :undefined ->
+        {:cowboy_websocket, req, _state = {channel, :pre_auth, Application.get_env(
+          :channel_sender_ex,
+          :message_encoder,
+          ChannelSenderEx.Transport.Encoders.JsonEncoder
+          )}, ws_opts()}
+
+      sub_protocols ->
+        {encoder, req} =
+          case Enum.member?(sub_protocols, "binary_flow") do
+            true ->
+              {BinaryEncoder,
+               :cowboy_req.set_resp_header("sec-websocket-protocol", "binary_flow", req)}
+
+            false ->
+              {JsonEncoder,
+               :cowboy_req.set_resp_header("sec-websocket-protocol", "json_flow", req)}
+          end
+
+        {:cowboy_websocket, req, _state = {channel, :pre_auth, encoder}, ws_opts()}
+    end
+  end
+
+  defp process_subprotocol_selection(err = {:error, _}, req) do
+    Logger.error("Socket unable to start. Error: #{inspect(err)}. Request: #{inspect(req)}")
+    err
+  end
+
+  @compile {:inline, notify_connected: 1}
+  defp notify_connected(channel) do
+    socket_event_bus = get_param(:socket_event_bus, nil)
+    ch_pid = socket_event_bus.notify_event({:connected, channel}, self())
+    Process.monitor(ch_pid)
+  end
+
+  @compile {:inline, set_pending: 2}
+  defp set_pending(state, new_pending), do: :erlang.setelement(5, state, new_pending)
+
+  @compile {:inline, remove_pending: 2}
+  defp remove_pending(state = {_, :connected, _, _, pending}, message_id) do
+    case Map.pop(pending, message_id) do
+      {nil, _} -> {nil, state}
+      {elem, new_pending} -> {elem, set_pending(state, new_pending)}
+    end
+  end
+
+  defp handle_terminate(:normal, _req, state) do
+    Logger.info("Socket with pid: #{inspect(self())} terminated with cause :normal. STATE: #{inspect(state)}")
+    :ok
+  end
+
+  defp handle_terminate(:remote, _req, state) do
+    Logger.info("Socket with pid: #{inspect(self())} terminated with cause :remote. STATE: #{inspect(state)}")
+    :ok
+  end
+
+  defp handle_terminate(cause = {:remote, _code, _}, _req, state) do
+    {channel_ref, _, _, _, _} = state
+    Logger.info("Socket with pid: #{inspect(self())}, for ref #{channel_ref} terminated normally. CAUSE: #{inspect(cause)}")
+    :ok
+  end
+
+  defp handle_terminate(:stop, _req, state) do
+    channel_ref = case state do
+      {ref, _, _} -> ref
+      {ref, _unauthorized_atom} -> ref
+      _ -> state
+    end
+    Logger.info("Socket with pid: #{inspect(self())}, for ref #{channel_ref} terminated with :stop. STATE: #{inspect(state)}")
+    :ok
+  end
+
+  defp handle_terminate(:timeout, _req, state) do
+    channel_ref = case state do
+      {ref, _, _} -> ref
+      {ref, _, _, _, _} -> ref
+      _ -> state
+    end
+    Logger.info("Socket with pid: #{inspect(self())}, for ref #{inspect(channel_ref)} terminated with :timeout. STATE: #{inspect(state)}")
+    :ok
+  end
+
+  defp handle_terminate({:error, :closed}, _req, state) do
+    channel_ref = case state do
+      {ref, _, _} -> ref
+      _ -> state
+    end
+    Logger.warning("Socket with pid: #{inspect(self())}, for ref #{inspect(channel_ref)} was closed without receiving closing frame first")
+    :ok
+  end
+
+  # handle other possible termination reasons:
+  # {:crash, Class, Reason}
+  # {:error, :badencoding | :badframe | :closed | Reason}
+  defp handle_terminate(reason, _req, state) do
+    Logger.info("Socket with pid: #{inspect(self())}, terminated with reason: #{inspect(reason)}. STATE: #{inspect(state)}")
+    :ok
   end
 
   @compile {:inline, auth_ok_frame: 1}
@@ -259,7 +403,7 @@ defmodule ChannelSenderEx.Transport.Socket do
   end
 
   defp ws_opts do
-    timeout = get_param(:socket_idle_timeout, 900)
+    timeout = get_param(:socket_idle_timeout, 90_000)
     %{
       idle_timeout: timeout,
       #      active_n: 5,

--- a/channel-sender/mix.exs
+++ b/channel-sender/mix.exs
@@ -4,7 +4,7 @@ defmodule ChannelSenderEx.MixProject do
   def project do
     [
       app: :channel_sender_ex,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/channel-sender/mix.exs
+++ b/channel-sender/mix.exs
@@ -4,7 +4,7 @@ defmodule ChannelSenderEx.MixProject do
   def project do
     [
       app: :channel_sender_ex,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/channel-sender/test/channel_sender_ex/core/channel_registry_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/channel_registry_test.exs
@@ -1,0 +1,32 @@
+Code.compiler_options(ignore_module_conflict: true)
+
+defmodule ChannelSenderEx.Core.ChannelRegistryTest do
+  use ExUnit.Case, sync: true
+  import Mock
+
+  alias ChannelSenderEx.Core.ChannelRegistry
+  alias Horde.Registry
+
+  @moduletag :capture_log
+
+  test "Should query by app" do
+    with_mocks([
+      {Registry, [], [
+        select: fn(_, _) -> [:c.pid(0, 255, 0), :c.pid(0, 254, 0)] end
+      ]}
+    ]) do
+      assert [_, _] = ChannelRegistry.query_by_app("app_ref") |> Enum.to_list()
+    end
+  end
+
+  test "Should query by user" do
+    with_mocks([
+      {Registry, [], [
+        select: fn(_, _) -> [:c.pid(0, 255, 0), :c.pid(0, 254, 0)] end
+      ]}
+    ]) do
+      assert [_, _] = ChannelRegistry.query_by_user("user_ref") |> Enum.to_list()
+    end
+  end
+
+end

--- a/channel-sender/test/channel_sender_ex/core/channel_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/channel_test.exs
@@ -5,6 +5,7 @@ defmodule ChannelSenderEx.Core.ChannelTest do
   import Mock
 
   alias ChannelSenderEx.Core.Channel
+  alias ChannelSenderEx.Core.Channel.Data
   alias ChannelSenderEx.Core.ChannelIDGenerator
   alias ChannelSenderEx.Core.ProtocolMessage
   alias ChannelSenderEx.Core.RulesProvider
@@ -62,6 +63,11 @@ defmodule ChannelSenderEx.Core.ChannelTest do
     message_to_send = ProtocolMessage.to_protocol_message(message)
     :accepted_connected = Channel.deliver_message(pid, message_to_send)
     assert_receive {:deliver_msg, _from = {^pid, _ref}, ^message_to_send}
+
+    {_, app, user} = init_args
+    data = %Data{application: app, user_ref: user}
+    assert data.application == app
+
     Process.exit(pid, :kill)
   end
 

--- a/channel-sender/test/channel_sender_ex/core/channel_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/channel_test.exs
@@ -48,7 +48,7 @@ defmodule ChannelSenderEx.Core.ChannelTest do
     end)
 
     {:ok,
-     init_args: {channel_ref, app, user_ref},
+     init_args: {channel_ref, app, user_ref, []},
      message: %{
        message_id: "32452",
        correlation_id: "1111",
@@ -64,7 +64,7 @@ defmodule ChannelSenderEx.Core.ChannelTest do
     :accepted_connected = Channel.deliver_message(pid, message_to_send)
     assert_receive {:deliver_msg, _from = {^pid, _ref}, ^message_to_send}
 
-    {_, app, user} = init_args
+    {_, app, user, []} = init_args
     data = %Data{application: app, user_ref: user}
     assert data.application == app
 
@@ -133,7 +133,7 @@ defmodule ChannelSenderEx.Core.ChannelTest do
     end)
   end
 
-  test "Should send new token in correct interval", %{init_args: init_args = {channel, _, _}} do
+  test "Should send new token in correct interval", %{init_args: init_args = {channel, _, _, _}} do
     Helper.compile(:channel_sender_ex, max_age: 2)
     {:ok, pid} = start_channel_safe(init_args)
     :sys.trace(pid, true)

--- a/channel-sender/test/channel_sender_ex/core/pubsub/pub_sub_core_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/pubsub/pub_sub_core_test.exs
@@ -1,20 +1,57 @@
 defmodule ChannelSenderEx.Core.PubSub.PubSubCoreTest do
   use ExUnit.Case
 
+  alias ChannelSenderEx.Core.Channel
   alias ChannelSenderEx.Core.ChannelRegistry
   alias ChannelSenderEx.Core.PubSub.PubSubCore
+
   import Mock
 
-  test "should retry when channel not found" do
+  test "should deliver to channel" do
+    with_mocks([
+      {ChannelRegistry, [], [
+        lookup_channel_addr: fn(_) -> :c.pid(0, 255, 0) end
+      ]},
+      {Channel, [], [deliver_message: fn(_, _) -> :accepted_connected end]}
+    ]) do
+      assert :accepted_connected == PubSubCore.deliver_to_channel("channel_ref", %{})
+      assert_called_exactly ChannelRegistry.lookup_channel_addr("channel_ref"), 1
+    end
+  end
 
+  test "should retry when channel not found" do
     with_mock(
       ChannelRegistry, [lookup_channel_addr: fn(_) -> :noproc end]
     ) do
-
       assert :error == PubSubCore.deliver_to_channel("channel_ref", %{})
-
+      assert_called_exactly ChannelRegistry.lookup_channel_addr("channel_ref"), 10
     end
+  end
 
+  test "should deliver to all channels associated with the given application reference" do
+    with_mocks([
+      {ChannelRegistry, [], [
+        query_by_app: fn(_) -> [:c.pid(0, 255, 0), :c.pid(0, 254, 0)] end
+      ]},
+      {Channel, [], [deliver_message: fn(_, _) -> :accepted_connected end]}
+    ]) do
+      assert  %{accepted_connected: 2} == PubSubCore.deliver_to_app_channels("app_ref", %{})
+      assert_called_exactly ChannelRegistry.query_by_app("app_ref"), 1
+      assert_called_exactly Channel.deliver_message(:_, :_), 2
+    end
+  end
+
+  test "should deliver to all channels associated with the given user reference" do
+    with_mocks([
+      {ChannelRegistry, [], [
+        query_by_user: fn(_) -> [:c.pid(0, 255, 0), :c.pid(0, 254, 0)] end
+      ]},
+      {Channel, [], [deliver_message: fn(_, _) -> :accepted_connected end]}
+    ]) do
+      assert  %{accepted_connected: 2} == PubSubCore.deliver_to_user_channels("user_ref", %{})
+      assert_called_exactly ChannelRegistry.query_by_user("user_ref"), 1
+      assert_called_exactly Channel.deliver_message(:_, :_), 2
+    end
   end
 
 end

--- a/channel-sender/test/channel_sender_ex/core/pubsub/pub_sub_core_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/pubsub/pub_sub_core_test.exs
@@ -54,4 +54,21 @@ defmodule ChannelSenderEx.Core.PubSub.PubSubCoreTest do
     end
   end
 
+  test "should handle call to delete (end) non-existent channel" do
+    with_mock(
+      ChannelRegistry, [lookup_channel_addr: fn(_) -> :noproc end]
+    ) do
+      assert :noproc == PubSubCore.delete_channel("channel_ref")
+    end
+  end
+
+  test "should handle call to delete (end) existent channel" do
+    with_mocks([
+      {ChannelRegistry, [], [lookup_channel_addr: fn(_) -> :c.pid(0, 255, 0) end]},
+      {Channel, [], [stop: fn(_) -> :ok end]}
+    ]) do
+      assert :ok == PubSubCore.delete_channel("channel_ref")
+    end
+  end
+
 end

--- a/channel-sender/test/channel_sender_ex/core/pubsub/re_connect_process_test.exs
+++ b/channel-sender/test/channel_sender_ex/core/pubsub/re_connect_process_test.exs
@@ -39,7 +39,7 @@ defmodule ChannelSenderEx.Core.PubSub.ReConnectProcessTest do
       {ChannelRegistry, [], [lookup_channel_addr: fn(_) -> :c.pid(0, 200, 0) end]},
       {Channel, [], [socket_connected: fn(_, _, _) -> :ok end]},
     ]) do
-      assert ReConnectProcess.connect_socket_to_channel("channel_ref", :c.pid(0, 250, 0)) == :ok
+      assert is_pid(ReConnectProcess.connect_socket_to_channel("channel_ref", :c.pid(0, 250, 0)))
     end
   end
 

--- a/channel-sender/test/channel_sender_ex/transport/rest/rest_controller_test.exs
+++ b/channel-sender/test/channel_sender_ex/transport/rest/rest_controller_test.exs
@@ -93,6 +93,226 @@ defmodule ChannelSenderEx.Transport.Rest.RestControllerTest do
 
   end
 
+  test "Should send message to app channels" do
+
+    body =
+      Jason.encode!(%{
+        app_ref: "app01",
+        message_id: "message_id",
+        correlation_id: "correlation_id",
+        message_data: "message_data",
+        event_name: "event_name"
+      })
+
+    with_mock PubSubCore, [deliver_to_app_channels: fn(_app_ref, _msg) ->
+      %{accepted_waiting: 1, accepted_connected: 3}
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_message", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 202
+
+      assert %{"result" => "Ok"} = Jason.decode!(conn.resp_body)
+
+      assert Enum.member?(conn.resp_headers, {"content-type", "application/json"})
+    end
+  end
+
+  test "Should send message to users channels" do
+
+    body =
+      Jason.encode!(%{
+        user_ref: "user01",
+        message_id: "message_id",
+        correlation_id: "correlation_id",
+        message_data: "message_data",
+        event_name: "event_name"
+      })
+
+    with_mock PubSubCore, [deliver_to_user_channels: fn(_user_ref, _msg) ->
+      %{accepted_waiting: 0, accepted_connected: 2}
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_message", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 202
+
+      assert %{"result" => "Ok"} = Jason.decode!(conn.resp_body)
+
+      assert Enum.member?(conn.resp_headers, {"content-type", "application/json"})
+    end
+  end
+
+  test "Should send message batch of max messages allowed" do
+
+    messages = Enum.map(1..10, fn i ->
+      %{
+        channel_ref: "channel_ref_#{i}",
+        message_id: "message_#{i}",
+        correlation_id: "correlation_id",
+        message_data: "message_data",
+        event_name: "event_name"
+      }
+    end) |> Enum.to_list()
+
+    body =
+      Jason.encode!(%{
+        messages: messages
+      })
+
+    with_mock PubSubCore, [deliver_to_channel: fn(_channel_ref, _msg) ->
+      :accepted_connected
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_batch", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 202
+
+      assert %{"result" => "Ok"} = Jason.decode!(conn.resp_body)
+
+      assert Enum.member?(conn.resp_headers, {"content-type", "application/json"})
+    end
+  end
+
+  test "Should send message batch of max allowed messages and discard the rest" do
+
+    messages = Enum.map(1..15, fn i ->
+      %{
+        channel_ref: "channel_ref_#{i}",
+        message_id: "message_#{i}",
+        correlation_id: "correlation_id",
+        message_data: "message_data",
+        event_name: "event_name"
+      }
+    end) |> Enum.to_list()
+
+    body =
+      Jason.encode!(%{
+        messages: messages
+      })
+
+    with_mock PubSubCore, [deliver_to_channel: fn(_channel_ref, _msg) ->
+      :accepted_connected
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_batch", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 202
+
+      result = Jason.decode!(conn.resp_body)
+      assert result["result"] == "partial-success"
+      assert result["accepted_messages"] == 10
+      assert result["discarded_messages"] == 5
+      assert length(result["discarded"]) == 5
+    end
+  end
+
+  test "Should handle invalid messages in a batch" do
+    messages = Enum.map(1..5, fn i ->
+      ref = if i == 5 do
+        ""
+      else
+        "ref00000_#{i}"
+      end
+      %{
+        channel_ref: ref,
+        message_id: "message_#{i}",
+        correlation_id: "correlation_id",
+        message_data: "message_data",
+        event_name: "event_name"
+      }
+    end) |> Enum.to_list()
+
+    body =
+      Jason.encode!(%{
+        messages: messages
+      })
+
+    with_mock PubSubCore, [deliver_to_channel: fn(_channel_ref, _msg) ->
+      :accepted_connected
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_batch", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 202
+
+      result = Jason.decode!(conn.resp_body)
+
+      assert result["result"] == "partial-success"
+      assert result["accepted_messages"] == 4
+      assert result["discarded_messages"] == 1
+      assert length(result["discarded"]) == 1
+    end
+  end
+
+  test "Should handle invalid request batch" do
+    body =
+      Jason.encode!(%{
+        messages: []
+      })
+
+    with_mock PubSubCore, [deliver_to_channel: fn(_channel_ref, _msg) ->
+      :accepted_connected
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_batch", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 400
+
+      result = Jason.decode!(conn.resp_body)
+
+      assert result["error"] == "Invalid request"
+      assert result["request"] == %{"messages" => []}
+
+    end
+  end
+
+  test "Should handle batch with all messages invalid" do
+    body =
+      Jason.encode!(%{
+        messages: [%{
+          channel_ref: "",
+          message_id: "message_1",
+          correlation_id: "correlation_id",
+          message_data: "message_data",
+          event_name: "event_name"
+        }]
+      })
+
+    with_mock PubSubCore, [deliver_to_channel: fn(_channel_ref, _msg) ->
+      :accepted_connected
+     end] do
+      conn = conn(:post, "/ext/channel/deliver_batch", body)
+        |> put_req_header("content-type", "application/json")
+
+      conn = RestController.call(conn, @options)
+
+      assert conn.status == 400
+
+      result = Jason.decode!(conn.resp_body)
+
+      assert result["error"] == "Invalid request"
+      assert result["request"] == %{"messages" => [%{"channel_ref" => "",
+        "correlation_id" => "correlation_id",
+        "event_name" => "event_name",
+        "message_data" => "message_data",
+        "message_id" => "message_1"}]}
+
+    end
+  end
+
   test "Should fail on invalid body" do
     body =
       Jason.encode!(%{

--- a/channel-sender/test/channel_sender_ex/transport/socket_integration_test.exs
+++ b/channel-sender/test/channel_sender_ex/transport/socket_integration_test.exs
@@ -102,7 +102,7 @@ defmodule ChannelSenderEx.Transport.SocketIntegrationTest do
     conn = connect(port, channel)
     assert_receive {:gun_upgrade, ^conn, stream, ["websocket"], _headers}
     :gun.ws_send(conn, {:text, "Auth::#{secret}Invalid"})
-    assert_receive {:gun_ws, ^conn, ^stream, {:close, 1008, "Invalid token for channel"}}
+    assert_receive {:gun_ws, ^conn, ^stream, {:close, 1001, "3008"}}
     assert_receive {:gun_down, ^conn, :ws, :closed, [], []}
     refute_receive {:gun_up, _conn, _}
     :gun.close(conn)
@@ -346,7 +346,7 @@ defmodule ChannelSenderEx.Transport.SocketIntegrationTest do
         sub_protocol -> connect(port, channel, sub_protocol)
       end
 
-    assert_receive {:gun_response, ^conn, stream, :fin, 400, _headers}, 1000
+    assert_receive {:gun_ws, ^conn, stream, {:close, 1001, "3050"}}, 1000
     {conn, stream}
   end
 


### PR DESCRIPTION
## Description

- The `/deliver_message` endpoint now supports sending messages to all channels related to a `application_ref` or even all channels related to an `user_ref`. Providing functionality to fan-out messages to several channels at time. Solves #34 

- Added new endpoint `/deliver_batch` to deliver up to 10 messages. This one is only for sending messages to explicit `channel_ref's`. Helpful when dealing with batches of messages to optimize roundtrips invoking less times the rest endpoint.

More details in the openapi document, included in `channel-sender/docs/swagger.yaml`

## Category

- [x] Feature
- [ ] Fix

## Checklist

- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/async-dataflow/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the mix.exs was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
